### PR TITLE
Use HTTP gateway to interact with backend instead of Web3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This is a demo application for a despository/registrar that showcases the user flow for file registration.
 
+It interacts with a HTTP gateway (see: registry-gateway in registry-contract), but can easily be converted to use Web3.
+
 ## Run and develop
 
 ```
@@ -12,3 +14,10 @@ yarn d
 yarn test
 yarn lint
 ```
+
+## Options
+
+As URL params:
+
+* `gateway=http://localhost:3000` URL override for HTTP gateway
+* `?step=1` Loads the corresponding tab for convenience

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -39,32 +39,69 @@ export const registerSubject = (
   owner: string,
   agent: string
 ) => (dispatch: Dispatch<ReceiveReceiptAction>) => {
-  Contracts.Registry.get()
-    .methods.register(`0x${subject}`, owner)
-    .send({ value: 10, from: agent, gas: 300000 })
-    .then(tx => {
-      dispatch(receiveReceipt(tx));
-      // tslint:disable-next-line:no-console
-      console.log(tx);
+  const token =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.2YjpwOJwv3SJ32kOeBqki0ee4UardV7SvPehZHW7MXw";
+
+  window
+    .fetch(`${window.gatewayUrl}/hash`, {
+      body: JSON.stringify({
+        hash: `0x${subject}`,
+        owner
+      }),
+      headers: new Headers({
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      }),
+      method: "POST"
     })
-    .then(() => dispatch(waitForTx()))
+    .then(res => res.json())
+    .then(res => {
+      dispatch(receiveReceipt(res.data));
+    })
     .catch(console.error);
+
+  // Directly using Web3:
+  // Contracts.Registry.get()
+  //   .methods.register(`0x${subject}`, owner)
+  //   .send({ value: 10, from: agent, gas: 300000 })
+  //   .then(tx => {
+  //     dispatch(receiveReceipt(tx));
+  //     // tslint:disable-next-line:no-console
+  //     console.log(tx);
+  //   })
+  //   .then(() => dispatch(waitForTx()))
+  //   .catch(console.error);
 };
 
 export const retrieveSubject = (subject: string) => (
   dispatch: Dispatch<Action>
 ) => {
-  Contracts.Registry.get()
-    .methods.retrieve(`0x${subject}`)
-    .call()
-    .then((result: any) => {
-      dispatch({
-        owner: result[1],
-        subject: result[2],
-        type: ActionTypes.RETRIEVE_SUBJECT
-      });
+  window
+    .fetch(`${window.gatewayUrl}/hash/0x${subject}`)
+    .then(res => res.json())
+    .then(res => {
+      if (res.data) {
+        dispatch({
+          owner: res.data.owner,
+          subject: res.data.hash,
+          type: ActionTypes.RETRIEVE_SUBJECT
+        });
+      }
     })
     .catch(console.log);
+
+  // Directly using Web3:
+  // Contracts.Registry.get()
+  //   .methods.retrieve(`0x${subject}`)
+  //   .call()
+  //   .then((result: any) => {
+  //     dispatch({
+  //       owner: result[1],
+  //       subject: result[2],
+  //       type: ActionTypes.RETRIEVE_SUBJECT
+  //     });
+  //   })
+  // .catch(console.log);
 };
 
 export const setHash = (hash: string) => ({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,7 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
 declare global {
   interface Window {
     web3: Web3;
+    gatewayUrl: string;
   }
 }
 
@@ -51,6 +52,8 @@ const provider =
   Web3.givenProvider || new Web3.providers.HttpProvider(endpoint);
 // const provider = Web3.givenProvider || new Web3.providers.WebsocketProvider(endpoint);
 window.web3 = new Web3(provider);
+
+window.gatewayUrl = url.searchParams.get("gateway") || "http://localhost:3000";
 
 const appReducer = combineReducers({
   ...reducers,


### PR DESCRIPTION
* This lets us abstract out the backend implementation (eg. Hashgraph instead of Ethereum)
* Web3 vestiges left in for now